### PR TITLE
Support configuration for ECJ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,78 @@ When applying the plugin to your project, all [JavaCompile](https://docs.gradle.
 
 ## Usage
 
-see https://plugins.gradle.org/plugin/com.gradle.plugin-publish
+Note: ECJ got new artifact group after 4.6.1 (original artifact group: org.eclipse.jdt.core.compiler), 
+the 4.6.1 version is for eclipse 4.6 and the 3.15.1 with artifact group org.eclipse.jdt for eclipse 4.9
+All versions from group org.eclipse.jdt.core.compiler considered as outdated even if version number looks higher then in the group org.eclipse.jdt
+
+### With default ECJ compiler and eclipse project specific ECJ settings (see de.set.gradle.ecj.EclipseCompilerBasePlugin.DEFAULT_VERSION)
+```gradle
+buildscript {
+	dependencies {
+		classpath 'gradle.plugin.de.set.gradle:gradle-eclipse-compiler-plugin:1.3.0'
+	}
+}
+
+plugins {
+	id 'de.set.ecj'
+	id 'java'
+}
+
+compileJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+compileTestJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+
+```
+
+### With specified ECJ compiler version and eclipse project specific ECJ settings
+```
+buildscript {
+	dependencies {
+		classpath 'gradle.plugin.de.set.gradle:gradle-eclipse-compiler-plugin:1.3.0'
+	}
+}
+
+plugins {
+	id 'de.set.ecj'
+	id 'java'
+}
+
+ecj.toolVersion = '3.15.1'
+
+compileJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+compileTestJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+
+```
+
+### With specified ECJ compiler artifact (OLD version) and eclipse project specific ECJ settings
+```
+buildscript {
+	dependencies {
+		classpath 'gradle.plugin.de.set.gradle:gradle-eclipse-compiler-plugin:1.3.0'
+	}
+}
+
+plugins {
+	id 'de.set.ecj'
+	id 'java'
+}
+
+ecj.toolGroupId = 'org.eclipse.jdt.core.compiler'
+ecj.toolArtifactId = 'ecj'
+ecj.toolVersion = '4.6.1'
+
+compileJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+compileTestJava {
+	options.compilerArgs << '-properties' << '$projectDir/.settings/org.eclipse.jdt.core.prefs'
+}
+
+```

--- a/src/main/java/de/set/gradle/ecj/EclipseCompilerAdapter.java
+++ b/src/main/java/de/set/gradle/ecj/EclipseCompilerAdapter.java
@@ -22,15 +22,18 @@ public class EclipseCompilerAdapter implements Compiler<JavaCompileSpec> {
   private static final Logger LOGGER = Logging.getLogger(EclipseCompilerAdapter.class);
   private Configuration compilerConfiguration;
   private Project project;
+  private String ecjArtifact;
 
   EclipseCompilerAdapter(Configuration compilerConfiguration, Project project) {
     this.compilerConfiguration = compilerConfiguration;
     this.project = project;
+    EclipseCompilerExtension extension = project.getExtensions().getByType(EclipseCompilerExtension.class);
+    this.ecjArtifact = extension.getToolGroupId()+":"+extension.getToolArtifactId()+":"+extension.getToolVersion();
   }
 
   @Override
   public WorkResult execute(JavaCompileSpec javaCompileSpec) {
-    LOGGER.info("Compiling sources using eclipse compiler for java");
+    LOGGER.info("Compiling sources using eclipse compiler for java ["+this.ecjArtifact+"]");
 
     final List<String> remainingArguments =
         new JavaCompilerArgumentsBuilder(javaCompileSpec).includeSourceFiles(true).build();

--- a/src/main/java/de/set/gradle/ecj/EclipseCompilerBasePlugin.java
+++ b/src/main/java/de/set/gradle/ecj/EclipseCompilerBasePlugin.java
@@ -12,14 +12,27 @@ public class EclipseCompilerBasePlugin implements Plugin<Project> {
   static final String ECJ_CONFIGURATION = "ecj";
   static final String ECJ_EXTENSION = "ecj";
 
-  private static final String DEFAULT_DEPENDENCY = "org.eclipse.jdt:ecj:";
-  private static final String DEFAULT_VERSION = "3.13.100";
+  private static final String DEFAULT_DEPENDENCY_GROUP = "org.eclipse.jdt";
+  private static final String DEFAULT_DEPENDENCY_ARTIFACT = "ecj";
+  private static final String DEFAULT_VERSION = "3.15.1";
+  
+  private boolean isEmpty(String str) {
+      return str == null || str.trim().length() == 0;
+  }
 
   @Override
   public void apply(Project project) {
     EclipseCompilerExtension extension =
         project.getExtensions().create(ECJ_EXTENSION, EclipseCompilerExtension.class);
-    extension.setToolVersion(DEFAULT_VERSION);
+    if (isEmpty(extension.getToolGroupId())) {
+        extension.setToolGroupId(DEFAULT_DEPENDENCY_GROUP);
+    }
+    if (isEmpty(extension.getToolArtifactId())) {
+        extension.setToolArtifactId(DEFAULT_DEPENDENCY_ARTIFACT);
+    }
+    if (isEmpty(extension.getToolVersion())) {
+      extension.setToolVersion(DEFAULT_VERSION);
+    }
 
     project
         .getConfigurations()
@@ -30,7 +43,9 @@ public class EclipseCompilerBasePlugin implements Plugin<Project> {
                   dependencies.add(
                       project
                           .getDependencies()
-                          .create(DEFAULT_DEPENDENCY + extension.getToolVersion()));
+                          .create(extension.getToolGroupId() + ":" + 
+                                  extension.getToolArtifactId() + ":" + 
+                                  extension.getToolVersion()));
                 }));
   }
 }

--- a/src/main/java/de/set/gradle/ecj/EclipseCompilerExtension.java
+++ b/src/main/java/de/set/gradle/ecj/EclipseCompilerExtension.java
@@ -5,7 +5,26 @@ package de.set.gradle.ecj;
  */
 public class EclipseCompilerExtension {
 
+  private String toolGroupId;
+  private String toolArtifactId;
   private String toolVersion;
+
+  
+  public String getToolGroupId() {
+	return toolGroupId;
+  }
+
+  public void setToolGroupId(String toolGroupId) {
+    this.toolGroupId = toolGroupId;
+    }
+	
+  public String getToolArtifactId() {
+    return toolArtifactId;
+    }
+	
+  public void setToolArtifactId(String toolArtifactId) {
+    this.toolArtifactId = toolArtifactId;
+    }
 
   public String getToolVersion() {
     return toolVersion;


### PR DESCRIPTION
Please merge this useful change and release a new version. This change focusing on the possibility to configure which ECJ version the user would like to use (also upgrades the default ECJ version to the newest 3.15.1).